### PR TITLE
Fix Hugo deployment: Add Go module support

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -25,17 +25,21 @@ jobs:
     env:
       HUGO_VERSION: 0.121.0
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
         run: sudo snap install dart-sass
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/windrise/windrise.github.io
+
+go 1.21
+
+require (
+	github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-plugin-netlify v1.0.0 // indirect
+	github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-plugin-netlify-cms v1.0.0 // indirect
+	github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy/v5 v5.8.1 // indirect
+)


### PR DESCRIPTION
- Add go.mod file for Hugo module dependencies
- Install Go 1.21 in GitHub Actions workflow
- Reorder workflow steps to checkout before installing tools

This fixes the deployment failure caused by missing Hugo modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)