### PR TITLE
Fix showcase view template errors

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -69,8 +69,9 @@ sections:
         folders:
           - project
     design:
-      columns: '3'
-      view: showcase
+      columns: '2'
+      view: card
+      flip_alt_rows: false
   - block: contact
     id: contact
     content:
@@ -79,7 +80,7 @@ sections:
       text: |-
         Feel free to reach out to me for research collaboration, academic discussions, or any questions about my work.
       # Contact (add or remove contact options as necessary)
-      email: your.email@example.com
+      email: 13621369872@163.com
       phone:
       appointment_url:
       address:
@@ -95,11 +96,7 @@ sections:
       coordinates:
         latitude:
         longitude:
-      contact_links:
-        - icon: twitter
-          icon_pack: fab
-          name: DM Me
-          link: 'https://twitter.com/yourusername'
+      contact_links: []
       # Automatically link email and phone or display as text?
       autolink: true
       # Email form provider

--- a/content/project/_index.md
+++ b/content/project/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Projects
-view: showcase
+view: card
 
 header:
   caption: ""


### PR DESCRIPTION
Replace 'showcase' view with 'card' view to fix template rendering errors:
- Update content/_index.md projects section to use card view
- Update content/project/_index.md to use card view
- Add flip_alt_rows parameter to prevent template errors
- Fix contact email to use real address
- Remove placeholder Twitter contact link

This fixes the error: "can't evaluate field design in type *hugolib.pageState" The showcase view requires specific design parameters that weren't configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)