### PR TITLE
Fix arXiv API compatibility issue

### DIFF
--- a/scripts/arxiv_scraper.py
+++ b/scripts/arxiv_scraper.py
@@ -94,7 +94,7 @@ class ArxivScraper:
                 "id": result.entry_id.split('/')[-1],
                 "title": result.title,
                 "authors": [author.name for author in result.authors],
-                "abstract": result.abstract,
+                "abstract": result.summary,  # Changed from result.abstract to result.summary
                 "published": result.published.strftime("%Y-%m-%d"),
                 "updated": result.updated.strftime("%Y-%m-%d"),
                 "categories": result.categories,


### PR DESCRIPTION
The arXiv Python library updated their API and deprecated the `result.abstract` attribute in favor of `result.summary`. This was causing AttributeError in the daily paper update workflow.

Changes:
- Updated arxiv_scraper.py line 97: result.abstract → result.summary
- This fixes the workflow Step 1 (paper fetching) which was failing

Fixes workflow error:
AttributeError: 'Result' object has no attribute 'abstract'