### PR TITLE
Fix missing Dict import in generate_audio.py

### DIFF
--- a/scripts/generate_audio.py
+++ b/scripts/generate_audio.py
@@ -9,6 +9,7 @@ import os
 import asyncio
 import edge_tts
 from pathlib import Path
+from typing import Dict
 
 
 class AudioGenerator:


### PR DESCRIPTION
Added missing typing.Dict import that was causing NameError in the audio generation step of the workflow.

Error fixed:
NameError: name 'Dict' is not defined. Did you mean: 'dict'?