### PR TITLE
Add paper review section to homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -37,6 +37,29 @@ sections:
         color: ''
       spacing:
         padding: ['20px', '0', '0', '0']
+  - block: markdown
+    content:
+      title: '🎯 Latest Reviewed Papers'
+      subtitle: 'Recently approved papers from the collection'
+      text: |
+        <div style="margin: 20px 0;">
+          {{< recent-papers limit="6" >}}
+        </div>
+
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="/papers/" style="display: inline-block; padding: 12px 30px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-weight: 600; transition: all 0.3s;">
+            📚 View All Papers →
+          </a>
+          <a href="https://github.com/windrise/windrise.github.io/issues?q=is%3Aissue+label%3Apaper-review" target="_blank" rel="noopener" style="display: inline-block; padding: 12px 30px; background: #f0f0f0; color: #333; text-decoration: none; border-radius: 8px; font-weight: 600; margin-left: 15px; transition: all 0.3s;">
+            🔍 Review Pending Papers →
+          </a>
+        </div>
+    design:
+      columns: '1'
+      background:
+        color: '#fafafa'
+      spacing:
+        padding: ['40px', '0', '40px', '0']
   - block: about.biography
     id: about
     content:

--- a/content/papers/index.md
+++ b/content/papers/index.md
@@ -1,19 +1,18 @@
 ---
 title: "Paper Collection"
 type: page
-layout: papers
 date: 2025-01-07
 ---
 
-# Awesome Papers in Medical Imaging & 3D Reconstruction
+# 📚 Awesome Papers Collection
 
-A curated collection of papers in my research areas, updated regularly.
+A curated collection of papers in my research areas: Medical Imaging, 3D Reconstruction & Gaussian Splatting, updated regularly through automated review workflow.
 
 <div class="stats-bar">
-  <span class="stat-item">📚 Total Papers: <strong>0</strong></span>
-  <span class="stat-item">🔥 Recently Added: <strong>0</strong></span>
-  <span class="stat-item">⭐ Favorites: <strong>0</strong></span>
-  <span class="stat-item">🕐 Last Updated: <strong>2025-01-07</strong></span>
+  <span class="stat-item">📚 Total Papers: <strong>{{ len site.Data.papers.papers }}</strong></span>
+  <span class="stat-item">🗂️ Categories: <strong>{{ len site.Data.papers.categories }}</strong></span>
+  <span class="stat-item">⭐ Starred: <strong>{{ len (where site.Data.papers.papers "starred" true) }}</strong></span>
+  <span class="stat-item">🕐 Last Updated: <strong>{{ site.Data.papers.metadata.last_updated }}</strong></span>
 </div>
 
 ---
@@ -21,254 +20,109 @@ A curated collection of papers in my research areas, updated regularly.
 ## 🔍 Quick Navigation
 
 <div class="category-nav">
-  <a href="#3d-gaussian" class="category-badge">3D Gaussian Splatting</a>
-  <a href="#medical-imaging" class="category-badge">Medical Image Analysis</a>
-  <a href="#cardiac-imaging" class="category-badge">Cardiac Imaging</a>
-  <a href="#self-supervised" class="category-badge">Self-Supervised Learning</a>
-  <a href="#nerf" class="category-badge">Neural Radiance Fields</a>
-  <a href="#reconstruction" class="category-badge">3D Reconstruction</a>
+{{- range site.Data.papers.categories -}}
+  <a href="#{{ .id }}" class="category-badge" style="background-color: {{ .color }};">{{ .icon }} {{ .name }}</a>
+{{- end -}}
+</div>
+
+<div style="text-align: center; margin: 30px 0;">
+  <a href="https://github.com/windrise/windrise.github.io/issues?q=is%3Aissue+label%3Apaper-review" target="_blank" rel="noopener" style="display: inline-block; padding: 12px 30px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-weight: 600; transition: all 0.3s;">
+    🔍 Review Pending Papers →
+  </a>
 </div>
 
 ---
 
-## <span id="3d-gaussian">🌟 3D Gaussian Splatting</span>
-
-### Foundation & Theory
-
-<div class="paper-card">
-  <div class="paper-header">
-    <h4>3D Gaussian Splatting for Real-Time Radiance Field Rendering</h4>
-    <span class="paper-badge venue">SIGGRAPH 2023</span>
-    <span class="paper-badge type">Foundation</span>
-  </div>
-  <div class="paper-meta">
-    <span class="authors">Kerbl et al.</span>
-    <span class="date">2023.08</span>
-  </div>
-  <p class="paper-abstract">
-    Introduces 3D Gaussian primitives for real-time rendering of neural radiance fields.
-  </p>
-  <div class="paper-links">
-    <a href="#" class="paper-link">📄 Paper</a>
-    <a href="#" class="paper-link">💻 Code</a>
-    <a href="#" class="paper-link">🎥 Demo</a>
-    <a href="#" class="paper-link">📝 Notes</a>
-  </div>
-</div>
-
-<!-- Placeholder for more papers -->
-<div class="coming-soon">
-  🚧 More papers coming soon... The automatic paper collection system is under development.
-</div>
+{{< all-papers >}}
 
 ---
 
-## <span id="medical-imaging">🏥 Medical Image Analysis</span>
-
-### Segmentation & Registration
-
-<div class="coming-soon">
-  📚 Papers will be automatically added from arXiv and major conferences.
-</div>
-
----
-
-## <span id="cardiac-imaging">❤️ Cardiac Imaging</span>
-
-<div class="coming-soon">
-  🫀 Cardiac motion tracking and analysis papers coming soon.
-</div>
-
----
-
-## <span id="self-supervised">🎯 Self-Supervised Learning</span>
-
-<div class="coming-soon">
-  🤖 Self-supervised learning papers for medical imaging.
-</div>
-
----
-
-## <span id="nerf">🌈 Neural Radiance Fields</span>
-
-<div class="coming-soon">
-  ✨ NeRF and related papers.
-</div>
-
----
-
-## <span id="reconstruction">🏗️ 3D Reconstruction</span>
-
-<div class="coming-soon">
-  🔨 3D reconstruction methods and applications.
-</div>
-
----
-
-## 🔄 Automatic Updates
+## 🔄 Automated Paper Collection System
 
 <div class="info-box">
-  <h3>🤖 Coming Soon: Automated Paper Collection</h3>
-  <p>This page will be automatically updated with:</p>
+  <h3>🤖 How It Works</h3>
+  <p>This collection is powered by an automated workflow:</p>
   <ul>
-    <li>📡 Latest papers from arXiv (daily scan)</li>
-    <li>🎯 Smart filtering based on research interests</li>
-    <li>⭐ Automatic categorization and tagging</li>
-    <li>📊 Citation tracking and impact metrics</li>
-    <li>🔊 AI-generated paper summaries and audio</li>
-    <li>💬 Interactive Q&A about papers</li>
-    <li>🗺️ Automatic mind map generation</li>
+    <li>📡 <strong>Daily arXiv Scan:</strong> Automatically fetches latest papers matching research keywords</li>
+    <li>🎯 <strong>Smart Filtering:</strong> AI-powered relevance scoring based on research interests</li>
+    <li>💬 <strong>AI Summaries:</strong> Automatic generation of paper summaries and key contributions</li>
+    <li>👥 <strong>GitHub Review:</strong> Papers are posted as issues for manual approval</li>
+    <li>✅ <strong>Auto-Update:</strong> Approved papers are automatically added to this page</li>
+    <li>⭐ <strong>Categorization:</strong> Smart categorization based on content analysis</li>
   </ul>
 </div>
 
 ---
 
-## 📮 Suggestions
+## 📮 Contribute
 
-Have a paper to recommend? [Open an issue](https://github.com/windrise/windrise.github.io/issues) or contact me directly!
+Have a paper to recommend? You can:
+- 🔍 [Review pending papers](https://github.com/windrise/windrise.github.io/issues?q=is%3Aissue+label%3Apaper-review) and approve them
+- 📝 [Open an issue](https://github.com/windrise/windrise.github.io/issues/new) to suggest a paper
+- 💬 Contact me directly with recommendations
 
 <style>
 .stats-bar {
   display: flex;
   justify-content: space-around;
   flex-wrap: wrap;
-  background: #f8f9fa;
-  padding: 20px;
-  border-radius: 10px;
-  margin: 20px 0;
+  background: linear-gradient(135deg, #667eea15 0%, #764ba215 100%);
+  padding: 25px;
+  border-radius: 12px;
+  margin: 30px 0;
+  border: 1px solid #e0e0e0;
 }
 
 .stat-item {
-  font-size: 0.95em;
-  color: #666;
+  font-size: 1em;
+  color: #555;
+  padding: 5px 15px;
+}
+
+.stat-item strong {
+  color: #667eea;
+  font-size: 1.3em;
+  display: block;
+  margin-top: 5px;
 }
 
 .category-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin: 20px 0;
+  gap: 12px;
+  margin: 30px 0;
+  justify-content: center;
 }
 
 .category-badge {
   display: inline-block;
-  padding: 8px 16px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
+  padding: 10px 20px;
+  color: white !important;
   border-radius: 20px;
   text-decoration: none;
-  font-size: 0.9em;
-  font-weight: 500;
+  font-size: 0.95em;
+  font-weight: 600;
   transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
 .category-badge:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
-}
-
-.paper-card {
-  background: white;
-  border: 1px solid #e0e0e0;
-  border-radius: 10px;
-  padding: 20px;
-  margin: 15px 0;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  transition: box-shadow 0.3s, transform 0.3s;
-}
-
-.paper-card:hover {
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  transform: translateY(-2px);
-}
-
-.paper-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-bottom: 10px;
-}
-
-.paper-header h4 {
-  margin: 0;
-  flex: 1;
-  min-width: 200px;
-  color: #2d3748;
-}
-
-.paper-badge {
-  padding: 4px 10px;
-  border-radius: 12px;
-  font-size: 0.8em;
-  font-weight: 600;
-}
-
-.paper-badge.venue {
-  background: #e3f2fd;
-  color: #1976d2;
-}
-
-.paper-badge.type {
-  background: #f3e5f5;
-  color: #7b1fa2;
-}
-
-.paper-meta {
-  display: flex;
-  gap: 15px;
-  font-size: 0.9em;
-  color: #666;
-  margin-bottom: 10px;
-}
-
-.paper-abstract {
-  color: #555;
-  line-height: 1.6;
-  margin: 10px 0;
-}
-
-.paper-links {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.paper-link {
-  padding: 6px 14px;
-  background: #f5f5f5;
-  border-radius: 6px;
-  text-decoration: none;
-  font-size: 0.85em;
-  color: #333;
-  transition: background 0.2s;
-}
-
-.paper-link:hover {
-  background: #e0e0e0;
-}
-
-.coming-soon {
-  text-align: center;
-  padding: 40px;
-  background: #fafafa;
-  border-radius: 10px;
-  color: #999;
-  font-size: 1.1em;
-  margin: 20px 0;
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.2);
 }
 
 .info-box {
-  background: linear-gradient(135deg, #667eea15 0%, #764ba215 100%);
+  background: linear-gradient(135deg, #667eea08 0%, #764ba208 100%);
   border-left: 4px solid #667eea;
-  padding: 25px;
-  border-radius: 8px;
-  margin: 30px 0;
+  padding: 30px;
+  border-radius: 12px;
+  margin: 40px 0;
 }
 
 .info-box h3 {
   margin-top: 0;
   color: #667eea;
+  font-size: 1.5em;
 }
 
 .info-box ul {
@@ -277,11 +131,16 @@ Have a paper to recommend? [Open an issue](https://github.com/windrise/windrise.
 }
 
 .info-box li {
-  padding: 8px 0;
+  padding: 12px 0;
   border-bottom: 1px solid #e0e0e0;
+  line-height: 1.6;
 }
 
 .info-box li:last-child {
   border-bottom: none;
+}
+
+.info-box strong {
+  color: #667eea;
 }
 </style>

--- a/layouts/shortcodes/all-papers.html
+++ b/layouts/shortcodes/all-papers.html
@@ -1,0 +1,344 @@
+{{- $papers := site.Data.papers.papers -}}
+{{- $categories := site.Data.papers.categories -}}
+
+<div class="all-papers-container">
+  {{- if $papers -}}
+    {{- $papersByCategory := dict -}}
+
+    {{- /* Group papers by their primary category */ -}}
+    {{- range $papers -}}
+      {{- if .categories -}}
+        {{- $primaryCat := index .categories 0 -}}
+        {{- $existing := index $papersByCategory $primaryCat -}}
+        {{- if $existing -}}
+          {{- $papersByCategory = merge $papersByCategory (dict $primaryCat (append $existing .)) -}}
+        {{- else -}}
+          {{- $papersByCategory = merge $papersByCategory (dict $primaryCat (slice .)) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{- /* Display papers by category */ -}}
+    {{- range $categories -}}
+      {{- $catPapers := index $papersByCategory .id -}}
+      {{- if $catPapers -}}
+        <div class="category-section" id="{{ .id }}">
+          <h2>
+            <span class="category-icon">{{ .icon }}</span>
+            {{ .name }}
+            <span class="paper-count">({{ len $catPapers }})</span>
+          </h2>
+          <p class="category-description">{{ .description }}</p>
+
+          <div class="papers-grid">
+            {{- $sortedPapers := sort $catPapers "date_added" "desc" -}}
+            {{- range $sortedPapers -}}
+              <div class="paper-card-full">
+                <div class="paper-header">
+                  <h4>
+                    <a href="{{ .links.paper }}" target="_blank" rel="noopener">{{ .title }}</a>
+                    {{- if .starred -}}<span class="star-icon">⭐</span>{{- end -}}
+                  </h4>
+                  <div class="paper-badges">
+                    {{- if .venue -}}<span class="badge venue-badge">{{ .venue }} {{ .year }}</span>{{- end -}}
+                    {{- if .type -}}<span class="badge type-badge">{{ .type }}</span>{{- end -}}
+                  </div>
+                </div>
+
+                <div class="paper-meta">
+                  <span class="authors">
+                    {{- $authors := first 5 .authors -}}
+                    {{- delimit $authors ", " -}}
+                    {{- if gt (len .authors) 5 -}}, et al.{{- end -}}
+                  </span>
+                  {{- if .relevance_score -}}
+                    <span class="relevance-badge">Relevance: {{ printf "%.1f" .relevance_score }}/10</span>
+                  {{- end -}}
+                </div>
+
+                {{- if .ai_summary -}}
+                  <p class="paper-abstract">{{ .ai_summary }}</p>
+                {{- else if .abstract -}}
+                  <p class="paper-abstract">{{ .abstract | truncate 300 }}</p>
+                {{- end -}}
+
+                {{- if .key_contributions -}}
+                  <div class="key-contributions">
+                    <strong>Key Contributions:</strong>
+                    <ul>
+                      {{- range first 3 .key_contributions -}}
+                        <li>{{ . | truncate 150 }}</li>
+                      {{- end -}}
+                    </ul>
+                  </div>
+                {{- end -}}
+
+                <div class="paper-footer">
+                  <div class="paper-links">
+                    {{- if .links.paper -}}
+                      <a href="{{ .links.paper }}" class="btn-link" target="_blank" rel="noopener">📄 Paper</a>
+                    {{- end -}}
+                    {{- if .links.code -}}
+                      <a href="{{ .links.code }}" class="btn-link" target="_blank" rel="noopener">💻 Code</a>
+                    {{- end -}}
+                    {{- if .links.project -}}
+                      <a href="{{ .links.project }}" class="btn-link" target="_blank" rel="noopener">🌐 Project</a>
+                    {{- end -}}
+                    {{- if .links.video -}}
+                      <a href="{{ .links.video }}" class="btn-link" target="_blank" rel="noopener">🎥 Video</a>
+                    {{- end -}}
+                  </div>
+                  <div class="paper-date">
+                    Added: {{ dateFormat "Jan 2, 2006" .date_added }}
+                  </div>
+                </div>
+              </div>
+            {{- end -}}
+          </div>
+        </div>
+      {{- end -}}
+    {{- end -}}
+
+  {{- else -}}
+    <div class="no-papers">
+      <h3>📚 No papers yet!</h3>
+      <p>Papers will appear here once they are approved.</p>
+      <a href="https://github.com/windrise/windrise.github.io/issues?q=is%3Aissue+label%3Apaper-review" target="_blank" class="review-link">
+        🔍 Review Pending Papers
+      </a>
+    </div>
+  {{- end -}}
+</div>
+
+<style>
+.all-papers-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.category-section {
+  margin: 50px 0;
+}
+
+.category-section h2 {
+  font-size: 2em;
+  margin-bottom: 10px;
+  color: #2d3748;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.category-icon {
+  font-size: 1.2em;
+}
+
+.paper-count {
+  font-size: 0.6em;
+  color: #666;
+  font-weight: normal;
+}
+
+.category-description {
+  color: #666;
+  margin-bottom: 30px;
+  font-size: 1.05em;
+}
+
+.papers-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.paper-card-full {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 24px;
+  transition: all 0.3s ease;
+}
+
+.paper-card-full:hover {
+  box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+  transform: translateY(-3px);
+  border-color: #667eea;
+}
+
+.paper-header h4 {
+  margin: 0 0 12px 0;
+  font-size: 1.25em;
+  line-height: 1.4;
+}
+
+.paper-header h4 a {
+  color: #2d3748;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.paper-header h4 a:hover {
+  color: #667eea;
+}
+
+.star-icon {
+  margin-left: 8px;
+  font-size: 0.8em;
+}
+
+.paper-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.badge {
+  padding: 5px 12px;
+  border-radius: 12px;
+  font-size: 0.8em;
+  font-weight: 600;
+}
+
+.venue-badge {
+  background: #e3f2fd;
+  color: #1976d2;
+}
+
+.type-badge {
+  background: #f3e5f5;
+  color: #7b1fa2;
+}
+
+.paper-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 15px;
+  font-size: 0.9em;
+  color: #666;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+}
+
+.authors {
+  flex: 1;
+}
+
+.relevance-badge {
+  background: #e8f5e9;
+  color: #2e7d32;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 0.85em;
+}
+
+.paper-abstract {
+  color: #555;
+  line-height: 1.7;
+  margin: 15px 0;
+}
+
+.key-contributions {
+  background: #f8f9fa;
+  padding: 15px;
+  border-radius: 8px;
+  margin: 15px 0;
+}
+
+.key-contributions strong {
+  color: #667eea;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.key-contributions ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.key-contributions li {
+  margin: 5px 0;
+  color: #555;
+  line-height: 1.5;
+}
+
+.paper-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+
+.paper-links {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.btn-link {
+  padding: 8px 16px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  text-decoration: none;
+  border-radius: 6px;
+  font-size: 0.85em;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.btn-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+.paper-date {
+  font-size: 0.85em;
+  color: #999;
+}
+
+.no-papers {
+  text-align: center;
+  padding: 60px 20px;
+  background: #fafafa;
+  border-radius: 12px;
+}
+
+.no-papers h3 {
+  font-size: 2em;
+  margin-bottom: 15px;
+}
+
+.review-link {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 12px 30px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  text-decoration: none;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 0.3s;
+}
+
+.review-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+}
+
+@media (max-width: 768px) {
+  .paper-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .paper-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/layouts/shortcodes/recent-papers.html
+++ b/layouts/shortcodes/recent-papers.html
@@ -1,0 +1,198 @@
+{{- $papers := site.Data.papers.papers -}}
+{{- $limit := .Get "limit" | default 5 -}}
+
+<div class="recent-papers-container">
+  {{- if $papers -}}
+    {{- $sortedPapers := sort $papers "date_added" "desc" -}}
+    {{- range first $limit $sortedPapers -}}
+      <div class="paper-card">
+        <div class="paper-header">
+          <h4><a href="{{ .links.paper }}" target="_blank" rel="noopener">{{ .title }}</a></h4>
+          <div class="paper-badges">
+            {{- if .venue -}}<span class="paper-badge venue">{{ .venue }} {{ .year }}</span>{{- end -}}
+            {{- if .type -}}<span class="paper-badge type">{{ .type }}</span>{{- end -}}
+            {{- if .starred -}}<span class="paper-badge starred">⭐ Starred</span>{{- end -}}
+          </div>
+        </div>
+
+        <div class="paper-meta">
+          <span class="authors">
+            {{- $authors := first 3 .authors -}}
+            {{- delimit $authors ", " -}}
+            {{- if gt (len .authors) 3 -}}, et al.{{- end -}}
+          </span>
+          <span class="date">{{ dateFormat "2006-01" .date_added }}</span>
+          {{- if .relevance_score -}}
+            <span class="relevance">Score: {{ printf "%.1f" .relevance_score }}</span>
+          {{- end -}}
+        </div>
+
+        {{- if .ai_summary -}}
+        <p class="paper-abstract">{{ .ai_summary | truncate 200 }}</p>
+        {{- else if .abstract -}}
+        <p class="paper-abstract">{{ .abstract | truncate 200 }}</p>
+        {{- end -}}
+
+        <div class="paper-categories">
+          {{- range .categories -}}
+            {{- $cat := index site.Data.papers.categories . -}}
+            {{- if $cat -}}
+              <span class="category-tag" style="background-color: {{ $cat.color }}20; color: {{ $cat.color }};">
+                {{ $cat.icon }} {{ $cat.name }}
+              </span>
+            {{- end -}}
+          {{- end -}}
+        </div>
+
+        <div class="paper-links">
+          {{- if .links.paper -}}
+            <a href="{{ .links.paper }}" class="paper-link" target="_blank" rel="noopener">📄 Paper</a>
+          {{- end -}}
+          {{- if .links.code -}}
+            <a href="{{ .links.code }}" class="paper-link" target="_blank" rel="noopener">💻 Code</a>
+          {{- end -}}
+          {{- if .links.project -}}
+            <a href="{{ .links.project }}" class="paper-link" target="_blank" rel="noopener">🌐 Project</a>
+          {{- end -}}
+        </div>
+      </div>
+    {{- end -}}
+  {{- else -}}
+    <div class="no-papers">
+      <p>📚 No papers yet. Start by reviewing pending papers!</p>
+    </div>
+  {{- end -}}
+</div>
+
+<style>
+.recent-papers-container {
+  margin: 20px 0;
+}
+
+.paper-card {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 20px;
+  margin: 15px 0;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  transition: all 0.3s ease;
+}
+
+.paper-card:hover {
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+  transform: translateY(-2px);
+}
+
+.paper-header {
+  margin-bottom: 12px;
+}
+
+.paper-header h4 {
+  margin: 0 0 8px 0;
+  font-size: 1.1em;
+  line-height: 1.4;
+}
+
+.paper-header h4 a {
+  color: #2d3748;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.paper-header h4 a:hover {
+  color: #667eea;
+}
+
+.paper-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.paper-badge {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.75em;
+  font-weight: 600;
+  display: inline-block;
+}
+
+.paper-badge.venue {
+  background: #e3f2fd;
+  color: #1976d2;
+}
+
+.paper-badge.type {
+  background: #f3e5f5;
+  color: #7b1fa2;
+}
+
+.paper-badge.starred {
+  background: #fff3e0;
+  color: #f57c00;
+}
+
+.paper-meta {
+  display: flex;
+  gap: 15px;
+  font-size: 0.85em;
+  color: #666;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.paper-abstract {
+  color: #555;
+  line-height: 1.6;
+  margin: 12px 0;
+  font-size: 0.9em;
+}
+
+.paper-categories {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 12px 0;
+}
+
+.category-tag {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.75em;
+  font-weight: 500;
+}
+
+.paper-links {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.paper-link {
+  padding: 6px 14px;
+  background: #f5f5f5;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.85em;
+  color: #333;
+  transition: all 0.2s;
+  border: 1px solid transparent;
+}
+
+.paper-link:hover {
+  background: #667eea;
+  color: white;
+  border-color: #667eea;
+}
+
+.no-papers {
+  text-align: center;
+  padding: 40px;
+  background: #fafafa;
+  border-radius: 10px;
+  color: #999;
+}
+</style>


### PR DESCRIPTION
- Add recent-papers shortcode to display latest approved papers on homepage
- Add all-papers shortcode to display categorized papers on papers page
- Update homepage with "Latest Reviewed Papers" section showing 6 newest papers
- Add "Review Pending Papers" button linking to GitHub issues
- Update papers page to dynamically display all approved papers by category
- Display paper metadata: authors, venue, relevance score, AI summaries
- Show key contributions and paper links (paper, code, project)
- Add statistics bar showing total papers, categories, and starred papers

Now users can:
- View latest approved papers directly on homepage
- Access full paper collection on /papers/ page
- Click "Review Pending Papers" to approve new papers via GitHub issues