### PR TITLE
🐛 Fix paper grouping logic using scratch

### DIFF
--- a/layouts/shortcodes/all-papers.html
+++ b/layouts/shortcodes/all-papers.html
@@ -4,24 +4,23 @@
 
 <div class="all-papers-container">
   {{- if $papers -}}
-    {{- $papersByCategory := dict -}}
-
-    {{- /* Group papers by their primary category */ -}}
+    {{- /* Group papers by their primary category using scratch */ -}}
+    {{- $scratch := newScratch -}}
     {{- range $papers -}}
       {{- if .categories -}}
         {{- $primaryCat := index .categories 0 -}}
-        {{- $existing := index $papersByCategory $primaryCat -}}
+        {{- $existing := $scratch.Get $primaryCat -}}
         {{- if $existing -}}
-          {{- $papersByCategory = merge $papersByCategory (dict $primaryCat (append $existing .)) -}}
+          {{- $scratch.Set $primaryCat (append $existing .) -}}
         {{- else -}}
-          {{- $papersByCategory = merge $papersByCategory (dict $primaryCat (slice .)) -}}
+          {{- $scratch.Set $primaryCat (slice .) -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}
 
     {{- /* Display papers by category */ -}}
     {{- range $categories -}}
-      {{- $catPapers := index $papersByCategory .id -}}
+      {{- $catPapers := $scratch.Get .id -}}
       {{- if $catPapers -}}
         <div class="category-section" id="{{ .id }}">
           <h2>


### PR DESCRIPTION
Replaced dict/merge approach with Hugo scratch to avoid type conflicts when grouping papers by category. This fixes the append error where $existing was incorrectly typed as map instead of slice.

Changes:
- Use newScratch instead of dict for paper grouping
- Replace $papersByCategory with $scratch.Get for category lookup

Fixes: error calling append: expected a slice, got map[string]interface {}