### PR TITLE
🐛 Use default function to ensure slice type safety

### DIFF
--- a/layouts/shortcodes/all-papers.html
+++ b/layouts/shortcodes/all-papers.html
@@ -9,12 +9,8 @@
     {{- range $paper := $papers -}}
       {{- if $paper.categories -}}
         {{- $primaryCat := index $paper.categories 0 -}}
-        {{- $existing := $scratch.Get $primaryCat -}}
-        {{- if $existing -}}
-          {{- $scratch.Set $primaryCat (append $existing $paper) -}}
-        {{- else -}}
-          {{- $scratch.Set $primaryCat (slice $paper) -}}
-        {{- end -}}
+        {{- $existing := default (slice) ($scratch.Get $primaryCat) -}}
+        {{- $scratch.Set $primaryCat (append $existing $paper) -}}
       {{- end -}}
     {{- end -}}
 


### PR DESCRIPTION
Simplified paper grouping logic using default function to guarantee $existing is always a slice type. This prevents type conflicts when $scratch.Get returns nil or unexpected types.

Changes:
- Removed if/else branching for $existing check
- Use default (slice) to ensure $existing is always a slice
- Simplified logic from 6 lines to 2 lines

Fixes: error calling append: expected a slice, got map[string]interface {}