### PR TITLE
🐛 Fix Hugo data path for recent-papers block

### DIFF
--- a/layouts/partials/blocks/recent-papers.html
+++ b/layouts/partials/blocks/recent-papers.html
@@ -12,7 +12,7 @@
       <p class="section-subtitle">{{ $block.content.subtitle | markdownify }}</p>
     {{- end -}}
 
-    {{- $papers := site.Data.papers.papers -}}
+    {{- $papers := site.Data.papers.papers.papers -}}
     {{- $limit := $block.content.count | default 6 -}}
 
     <div class="recent-papers-container">
@@ -49,7 +49,7 @@
 
             <div class="paper-categories">
               {{- range .categories -}}
-                {{- $cat := index site.Data.papers.categories . -}}
+                {{- $cat := index site.Data.papers.papers.categories . -}}
                 {{- if $cat -}}
                   <span class="category-tag" style="background-color: {{ $cat.color }}20; color: {{ $cat.color }};">
                     {{ $cat.icon }} {{ $cat.name }}


### PR DESCRIPTION
Fixed the data access paths in the recent-papers partial block to match the nested structure created by data/papers/papers.yaml file location.

Changes:
- Updated $papers to access site.Data.papers.papers.papers
- Updated category lookup to use site.Data.papers.papers.categories

This matches the fix applied to all-papers.html shortcode and resolves the sort error on date_added field.

Fixes: error calling sort: date_added is neither a struct field, a method nor a map element