### PR TITLE
🐛 Fix category lookup using where filter

### DIFF
--- a/layouts/partials/blocks/recent-papers.html
+++ b/layouts/partials/blocks/recent-papers.html
@@ -48,9 +48,8 @@
             {{- end -}}
 
             <div class="paper-categories">
-              {{- range .categories -}}
-                {{- $cat := index site.Data.papers.papers.categories . -}}
-                {{- if $cat -}}
+              {{- range $catID := .categories -}}
+                {{- range $cat := where site.Data.papers.papers.categories "id" $catID -}}
                   <span class="category-tag" style="background-color: {{ $cat.color }}20; color: {{ $cat.color }};">
                     {{ $cat.icon }} {{ $cat.name }}
                   </span>


### PR DESCRIPTION
Changed from index lookup to where filter for finding categories by ID. The categories data is an array, not a map, so we need to use where to filter by the "id" field rather than using index with a string key.

Changes:
- Use where filter to find category by ID
- Changed from: index site.Data.papers.papers.categories .
- Changed to: where site.Data.papers.papers.categories "id" $catID

Fixes: error calling index: cannot index slice/array with type string