### PR TITLE
✨ Simplify homepage by removing recent-papers block

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -37,15 +37,15 @@ sections:
         color: ''
       spacing:
         padding: ['20px', '0', '0', '0']
-  - block: recent-papers
-    content:
-      title: '🎯 Latest Reviewed Papers'
-      subtitle: 'Recently approved papers from the collection'
-      count: 6
-    design:
-      columns: '1'
-      spacing:
-        padding: ['0', '0', '0', '0']
+  # - block: recent-papers
+  #   content:
+  #     title: '🎯 Latest Reviewed Papers'
+  #     subtitle: 'Recently approved papers from the collection'
+  #     count: 6
+  #   design:
+  #     columns: '1'
+  #     spacing:
+  #       padding: ['0', '0', '0', '0']
   - block: about.biography
     id: about
     content:


### PR DESCRIPTION
Commented out the recent-papers block on the homepage to keep the homepage clean and focused. Users can still access all papers by clicking the "Research Paper Collection" card.

This prevents the detailed paper listings from overwhelming the homepage content and provides a better user experience.