### PR TITLE
🔧 Disable site-wide search to fix index.json 404 error

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -22,7 +22,7 @@ header:
     show_logo: true
     show_language: false
     show_day_night: true
-    show_search: true
+    show_search: false
     highlight_active_link: true
 
 footer:


### PR DESCRIPTION
The 404 error for index.json was blocking JavaScript execution on the papers page. Since the papers page has its own built-in search functionality, the site-wide Wowchemy search feature is not needed.

Changes:
- Set show_search: false in config/_default/params.yaml
- This prevents the theme from trying to load index.json
- Papers page has its own dedicated search interface

This should resolve the "interface not responding" issue.