### PR TITLE
🔧 Completely disable search provider to fix index.json 404

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -59,7 +59,7 @@ features:
     commento:
       url: ''
   search:
-    provider: wowchemy
+    provider: ''
     algolia:
       app_id: ''
       api_key: ''


### PR DESCRIPTION
Set search provider to empty string to fully disable the Wowchemy search functionality that requires index.json. This complements the previous fix that disabled show_search in navbar.

Changes:
- Set provider: '' in search configuration
- This prevents vendor-bundle.js from trying to load index.json
- Papers page has its own search, so site-wide search is not needed