### PR TITLE
🐛 Fix JSON parsing error in paper data attributes

### DIFF
--- a/layouts/shortcodes/all-papers-enhanced.html
+++ b/layouts/shortcodes/all-papers-enhanced.html
@@ -128,8 +128,8 @@
         data-type="{{ $paper.type }}"
         data-relevance="{{ $paper.relevance_score | default 0 }}"
         data-citation="{{ $paper.citation_count | default 0 }}"
-        data-search-text="{{ lower (printf "%s %s %s" $paper.title (delimit $paper.authors " ") $paper.abstract) }}"
-        data-paper-data='{{ dict "title" $paper.title "authors" $paper.authors "venue" $paper.venue "year" $paper.year "arxiv_id" $paper.arxiv_id "links" $paper.links "abstract" $paper.abstract | jsonify }}'
+        data-search-text="{{ lower (printf "%s %s %s" $paper.title (delimit $paper.authors " ") ($paper.abstract | default "")) }}"
+        data-paper-data="{{ dict "title" $paper.title "authors" $paper.authors "venue" $paper.venue "year" $paper.year "arxiv_id" ($paper.arxiv_id | default "") "links" $paper.links | jsonify | htmlEscape }}"
       >
         <!-- Selection Checkbox -->
         <div class="paper-checkbox" style="display: none;">


### PR DESCRIPTION
The abstract field contained special characters (quotes, colons, newlines) that were breaking JSON serialization when embedded in HTML attributes. This caused JavaScript parsing errors and made the interface unresponsive.

Changes:
- Removed abstract from data-paper-data attribute (too long, special chars)
- Changed from single quotes to double quotes for attribute value
- Added htmlEscape filter for proper HTML escaping
- Added default empty string for arxiv_id to handle nil values
- Abstract is still displayed in UI, just not stored in data attribute
- Export functions will work without abstract (can be added back differently later)

This should fix the "cite" error popup and interface responsiveness issue.