### PR TITLE
🐛 Remove htmlEscape filter to fix JSON parsing

### DIFF
--- a/layouts/shortcodes/all-papers-enhanced.html
+++ b/layouts/shortcodes/all-papers-enhanced.html
@@ -129,7 +129,7 @@
         data-relevance="{{ $paper.relevance_score | default 0 }}"
         data-citation="{{ $paper.citation_count | default 0 }}"
         data-search-text="{{ lower (printf "%s %s %s" $paper.title (delimit $paper.authors " ") ($paper.abstract | default "")) }}"
-        data-paper-data="{{ dict "title" $paper.title "authors" $paper.authors "venue" $paper.venue "year" $paper.year "arxiv_id" ($paper.arxiv_id | default "") "links" $paper.links | jsonify | htmlEscape }}"
+        data-paper-data='{{ dict "title" $paper.title "authors" $paper.authors "venue" ($paper.venue | default "") "year" $paper.year "arxiv_id" ($paper.arxiv_id | default "") "links" $paper.links | jsonify }}'
       >
         <!-- Selection Checkbox -->
         <div class="paper-checkbox" style="display: none;">


### PR DESCRIPTION
The htmlEscape filter was converting JSON quotes to &quot; entities, making the JSON unparseable by JavaScript.

Changes:
- Removed htmlEscape filter from data-paper-data attribute
- Using single quotes for attribute wrapper (safer for JSON with double quotes)
- Added default empty string for venue field
- Keep minimal data in JSON: title, authors, venue, year, arxiv_id, links

This should resolve the "Expected property name or '}' in JSON" error.